### PR TITLE
add ujson pin, pip check

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -9,4 +9,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- 3.6.* *_cpython

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,8 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -33,7 +34,7 @@ conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,8 +52,10 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Allow people to specify extra default arguments to `docker run` (e.g. `--rm`)
+DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
-    DOCKER_RUN_ARGS="-it "
+    DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
@@ -21,12 +21,16 @@ requirements:
   run:
     - python
     - future
-    - ujson
+    - ujson <=1.35
 
 test:
+  requires:
+    - pip
   imports:
     - pyls_jsonrpc
     - pyls_jsonrpc.dispatchers
+  commands:
+    - python -m pip check
 
 about:
   home: https://github.com/palantir/python-jsonrpc-server


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Have seen this a few times, most recently with a mixed install of conda/pip stuff that ended up with some inconsistent versions:

```
pkg_resources.ContextualVersionConflict: (ujson 2.0.3 (/opt/conda/lib/python3.7/site-packages), Requirement.parse('ujson<=1.35; platform_system != "Windows"'), {'python-jsonrpc-server'})
```

this should help keep us honest until something better comes along.

Provided this is merged, I guess we might want to mark `0` broken?